### PR TITLE
Updated description

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -21,7 +21,7 @@
 
   <!-- Meta -->
   <meta content="YouBase" property="og:title">
-  <meta content="Your Project description goes here." name="description">
+  <meta content="Enabling Health DataSharing." name="description">
 
   <!-- Initializer -->
   <script>


### PR DESCRIPTION
Updated the description to match the public website, so social link
shares don't show the placeholder text as a description